### PR TITLE
Use `if ! defined` instead of ensure_resource()

### DIFF
--- a/manifests/source/project.pp
+++ b/manifests/source/project.pp
@@ -23,12 +23,29 @@ define sentry::source::project (
   $path = $::sentry::path,
 ) {
 
-  $params = { command => "${path}/bin/python ${path}/create_project.py -p ${project} -l ${platform}",
-              creates => "${path}/dsn/${project}",
-              require => File["${path}/create_project.py"],
-            }
   # create exactly one project, regardless of how many app
-  # servers might be running the corresponding application
-  ensure_resource('exec', "Add ${project}", $params)
+  # servers might be running the corresponding application.
+  #
+  # We use `if ! defined` here because we don't want catalog
+  # compilation to fail in the event that a project's platform
+  # changes for any reason. Such a change might be due to an
+  # unexpected error, or by intentional operator decision.
+  #
+  # Projects are created in the default organization and team
+  # as defined in the `sentry::init`.  Multiple projects can use
+  # the same name as long as they are in different teams (or
+  # organizations).  This requires manual modification of projects
+  # after they have been created, and is outside the scope of
+  # this module.  Additionally, automatic creation of a new project
+  # may fail if a prior project of the same name still has a DSN file
+  # present at `${path}/dsn/${project}`
+
+  if ! defined( Exec["Add ${project}"] ) {
+    exec { "Add ${project}":
+      command => "${path}/bin/python ${path}/create_project.py -p ${project} -l ${platform}",
+      creates => "${path}/dsn/${project}",
+      require => File["${path}/create_project.py"],
+    }
+  }
 
 }


### PR DESCRIPTION
It might be the case that a project's platform may change (intentionally
or otherwise).  In that case, catalog compilation will fail if we use
`ensure_resource()` on the `sentry::source::project` Exec.

Use `if ! defined` instead, to ensure that once a project has been
created, any changes won't break the catalog.
