### PR TITLE
Add cleanup cronjob; fix dsn_mapper.py

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,13 +162,22 @@ class sentry (
     require => File["${path}/sentry.conf"],
   }
 
+  # this creates the DSN file for each project, daily.
   cron { 'dsn_mapper':
     command => "${path}/bin/python ${path}/dsn_mapper.py",
     user    => root,
-    minute  => 5
+    minute  => 5,
+    hour    => 2,
   }
 
-  # Collect the projects from exported resources
+  # run the Sentry cleanup process daily
+  cron { 'sentry cleanup':
+    command => "${path}/bin/sentry --config=${path}/sentry.conf cleanup --days=30",
+    user    => $user,
+    minute  => 15,
+    hour    => 1,
+  }
+
   file { "${path}/create_project.py":
     ensure  => present,
     mode    => '0755',
@@ -176,6 +185,7 @@ class sentry (
     require => File["${path}/sentry.conf"],
   }
 
+  # Collect the projects from exported resources
   include sentry::server::collect
 
 }

--- a/templates/dsn_mapper.py.erb
+++ b/templates/dsn_mapper.py.erb
@@ -1,7 +1,7 @@
 import os, sys, site
 
-site.addsitedir('<%= @venv %>')
-os.environ['SENTRY_CONF'] = '<%= @venv %>/sentry.conf'
+site.addsitedir('<%= @path %>')
+os.environ['SENTRY_CONF'] = '<%= @path %>/sentry.conf'
 
 # Check to see if the project exists on the team
 from sentry.utils.runner import configure


### PR DESCRIPTION
Add a cronjonb that runs every day to clean up old Sentry data.
Update the dsn_mapper.py to use @path instead of @venv.
Update the dsn_mapper cronjob to only run once per day.

Should we make the dsn_mapper cronjob optional?  Would be a trivial
change.
