### PR TITLE
django-auth-ldap is hyphens, not underscores

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,7 +93,7 @@ class sentry::install (
   }
 
   $pip_dependencies = [
-    'django_auth_ldap',
+    'django-auth-ldap',
     'hiredis',
     'nydus',
     'psycopg2',


### PR DESCRIPTION
fixes puppet always changing
