### PR TITLE
Use 'w' instead of 'a' when opening the DSN cache

### DIFF
--- a/templates/dsn_mapper.py.erb
+++ b/templates/dsn_mapper.py.erb
@@ -32,7 +32,7 @@ for project in Project.objects.all():
         doit = True
 
       if doit:
-        new_dsn = open(dsn_file, 'a')
+        new_dsn = open(dsn_file, 'w')
         new_dsn.write(dsn)
         new_dsn.close()
 


### PR DESCRIPTION
The use of 'a' to append to the DSN cache file is causing duplicate
entries to be inserted.  We should use 'w' to write to the file to
ensure that it is only one line.
