### PR TITLE
Allow projects to be created in teams

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -115,7 +115,7 @@ class sentry::install (
   # resolution may install an older version of Sentry, which would
   # then be promptly upgraded.
   python::pip { 'sentry-ldap-auth':
-    version => $ldap_auth_version,
+    ensure  => $ldap_auth_version,
     require => Python::Pip['sentry'],
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,7 +32,7 @@ class sentry::service (
 
   file { '/etc/systemd/system/sentry-worker.service':
     ensure  => present,
-    mode    => '0755',
+    mode    => '0644',
     owner   => 'root',
     group   => 'root',
     content => template('sentry/sentry-worker.service.erb'),

--- a/manifests/source/export.pp
+++ b/manifests/source/export.pp
@@ -50,12 +50,28 @@ define sentry::source::export (
     $real_lang = $language
   }
 
+  if (! $organization) or ($organization == '') {
+    # an empty string or "undef" was passed. Use the default
+    # organization.
+    $o = $::sentry::organization
+  } else {
+    $o = $organization
+  }
+
+  if (! $team) or ($team == '') {
+    # an empty string or "undef" was passed. Use the default team.
+    $t = $::sentry::team
+  } else {
+    $t = $team
+  }
+
   # Export a Sentry project. Resource has the hostname so its unique.
   @@sentry::source::project { "${name}-${::hostname}":
-    project  => $name,
-    platform => $real_lang,
-    team     => $team,
-    tag      => $env,
+    organization => $o,
+    project      => $name,
+    platform     => $real_lang,
+    team         => $t,
+    tag          => $env,
   }
 
 }

--- a/manifests/source/export.pp
+++ b/manifests/source/export.pp
@@ -45,9 +45,9 @@ define sentry::source::export (
   # module.  You're on your own to create and use it.
   $override_language = getvar("${name}_lang")
   if $override_language {
-    $real_lang = $override_language
+    $l = $override_language
   } else {
-    $real_lang = $language
+    $l = $language
   }
 
   if (! $organization) or ($organization == '') {
@@ -69,7 +69,7 @@ define sentry::source::export (
   @@sentry::source::project { "${name}-${::hostname}":
     organization => $o,
     project      => $name,
-    platform     => $real_lang,
+    platform     => $l,
     team         => $t,
     tag          => $env,
   }

--- a/manifests/source/export.pp
+++ b/manifests/source/export.pp
@@ -32,10 +32,10 @@
 # Copyright 2015 CoverMyMeds
 #
 define sentry::source::export (
-  $language     = 'Other',
-  $organization = $::sentry::organization,
-  $team         = $::sentry::team,
-  $env          = undef,
+  $organization,
+  $team,
+  $env,
+  $language = 'Other',
 ) {
 
   # Allow for a custom fact named appname_lang.
@@ -45,32 +45,17 @@ define sentry::source::export (
   # module.  You're on your own to create and use it.
   $override_language = getvar("${name}_lang")
   if $override_language {
-    $l = $override_language
+    $real_lang = $override_language
   } else {
-    $l = $language
-  }
-
-  if (! $organization) or ($organization == '') {
-    # an empty string or "undef" was passed. Use the default
-    # organization.
-    $o = $::sentry::organization
-  } else {
-    $o = $organization
-  }
-
-  if (! $team) or ($team == '') {
-    # an empty string or "undef" was passed. Use the default team.
-    $t = $::sentry::team
-  } else {
-    $t = $team
+    $real_lang = $language
   }
 
   # Export a Sentry project. Resource has the hostname so its unique.
   @@sentry::source::project { "${name}-${::hostname}":
-    organization => $o,
+    organization => $organization,
     project      => $name,
-    platform     => $l,
-    team         => $t,
+    platform     => $real_lang,
+    team         => $team,
     tag          => $env,
   }
 

--- a/manifests/source/export.pp
+++ b/manifests/source/export.pp
@@ -7,6 +7,12 @@
 # [*language*]: 
 #   the Sentry language to use
 #
+# [*organization*]:
+#   the organization to which the project is assigned
+#
+# [*team*]:
+#   the team to which this project is assigned
+#
 # [*env*]
 #   the tag to apply
 #
@@ -26,8 +32,10 @@
 # Copyright 2015 CoverMyMeds
 #
 define sentry::source::export (
-  $language = 'Other',
-  $env      = undef,
+  $language     = 'Other',
+  $organization = $::sentry::organization,
+  $team         = $::sentry::team,
+  $env          = undef,
 ) {
 
   # Allow for a custom fact named appname_lang.
@@ -46,6 +54,7 @@ define sentry::source::export (
   @@sentry::source::project { "${name}-${::hostname}":
     project  => $name,
     platform => $real_lang,
+    team     => $team,
     tag      => $env,
   }
 

--- a/manifests/source/export.pp
+++ b/manifests/source/export.pp
@@ -32,10 +32,10 @@
 # Copyright 2015 CoverMyMeds
 #
 define sentry::source::export (
-  $organization,
-  $team,
-  $env,
-  $language = 'Other',
+  String $organization,
+  String $team,
+  String $env,
+  String $language = 'Other',
 ) {
 
   # Allow for a custom fact named appname_lang.

--- a/manifests/source/project.pp
+++ b/manifests/source/project.pp
@@ -21,11 +21,11 @@
 #
 # lint:ignore:parameter_documentation
 define sentry::source::project (
-  $organization,
-  $project,
-  $platform,
-  $team,
-  $path = $::sentry::path,
+  String $organization,
+  String $project,
+  String $platform,
+  String $team,
+  String $path = $::sentry::path,
 ) {
 # lint:endignore
 

--- a/manifests/source/project.pp
+++ b/manifests/source/project.pp
@@ -29,21 +29,11 @@ define sentry::source::project (
 ) {
 # lint:endignore
 
-  # normalize the project name to lowercase
+  # normalize the inputs to lowercase
   $proj = downcase($project)
-
-  if ($organization == $::sentry::organization) and ($team == $::sentry::team) {
-    # if this project is being created in the default team, just use
-    # the project name for the Exec resource and the DSN cache file.
-    $p = $proj
-  } else {
-    # if this project is not in the default organization and team,
-    # set the DSN cache file to use the full org + team + project.
-    # Be sure the uriescape the resulting string!
-    $o = downcase($organization)
-    $t = downcase($team)
-    $p = uriescape("${o}-${t}-${proj}")
-  }
+  $o = downcase($organization)
+  $t = downcase($team)
+  $p = uriescape("${o}-${t}-${proj}")
 
   # create exactly one project, regardless of how many app
   # servers might be running the corresponding application.
@@ -57,7 +47,6 @@ define sentry::source::project (
   # changes for any reason. Such a change might be due to an
   # unexpected error, or by intentional operator decision.
   #
-
   if ! defined( Exec["Add ${organization}-${team}-${project}"] ) {
     exec { "Add ${organization}-${team}-${project}":
       command => "${path}/bin/python ${path}/create_project.py -o ${organization} -t ${team} -l ${platform} -p ${project}",

--- a/manifests/source/project.pp
+++ b/manifests/source/project.pp
@@ -4,9 +4,11 @@
 # doesn't exist.
 #
 # === Parameters
+# organization: the organization to which this project is assigned
 # project: the name of the project
 # platform: the language used by this project
 # path: the virtualenv path to use for Sentry
+# team: the team to which the project is assigned
 #
 # === Authors
 #
@@ -18,8 +20,10 @@
 # Copyright 2015 CoverMyMeds
 #
 define sentry::source::project (
+  $organization,
   $project,
   $platform,
+  $team,
   $path = $::sentry::path,
 ) {
 
@@ -31,19 +35,22 @@ define sentry::source::project (
   # changes for any reason. Such a change might be due to an
   # unexpected error, or by intentional operator decision.
   #
-  # Projects are created in the default organization and team
-  # as defined in the `sentry::init`.  Multiple projects can use
-  # the same name as long as they are in different teams (or
-  # organizations).  This requires manual modification of projects
-  # after they have been created, and is outside the scope of
-  # this module.  Additionally, automatic creation of a new project
-  # may fail if a prior project of the same name still has a DSN file
-  # present at `${path}/dsn/${project}`
 
-  if ! defined( Exec["Add ${project}"] ) {
-    exec { "Add ${project}":
-      command => "${path}/bin/python ${path}/create_project.py -p ${project} -l ${platform}",
-      creates => "${path}/dsn/${project}",
+  if ($organization == $::sentry::organization) and ($team == $::sentry::team) {
+    # if this project is being created in the default team, just use
+    # the project name for the Exec resource and the DSN cache file.
+    $p = $project
+  } else {
+    # if this project is being created in a new team, create a namespace
+    # using "team/project" format. This will be used for the Exec and
+    # the DSN cache file.  Be sure the uriescape the resulting string!
+    $p = uriescape("${organization}/${team}/${project}")
+  }
+
+  if ! defined( Exec["Add ${p}"] ) {
+    exec { "Add ${p}":
+      command => "${path}/bin/python ${path}/create_project.py -o ${organization} -t ${team} -l ${platform} -p ${project}",
+      creates => "${path}/dsn/${p}",
       require => File["${path}/create_project.py"],
     }
   }

--- a/templates/create_project.py.erb
+++ b/templates/create_project.py.erb
@@ -87,11 +87,7 @@ def main():
 
   # create a static file containing this application's DSN
   k = ProjectKey.objects.get(project_id=p.id).get_dsn()
-  prefix = ''
-  if options.organization != '<%= @organization %>' or options.team != '<%= @team %>':
-    # this project does not live in the default org+team, so create the
-    # DSN file with a url-encoded prefix of "organization-team-"
-    prefix = quote(o.name.lower() + "-" + t.name.lower() + "-")
+  prefix = quote(o.name.lower() + "-" + t.name.lower() + "-")
   dsn = open('<%= @path %>/dsn/' + prefix + p.name, 'a')
   dsn.write(k)
   dsn.close()

--- a/templates/create_project.py.erb
+++ b/templates/create_project.py.erb
@@ -46,7 +46,7 @@ def main():
 
   # try to load the requested team
   try:
-    t = Team.objects.get(name=options.team)
+    t = Team.objects.get(name=options.team,organization_id=o.id)
   except:
     # this team does not yet exist.  Create it.
     t = Team()
@@ -55,7 +55,7 @@ def main():
     t.owner_id = u.id
     t.save()
     # reload the object
-    t = Team.objects.get(name=options.team)
+    t = Team.objects.get(name=options.team,organization_id=o.id)
 
   try:
     p = Project.objects.get(name=options.project,team_id=t.id)
@@ -64,7 +64,7 @@ def main():
 
   if p:
     if options.verbose:
-      print 'Project %s exists in team %s' % (options.project, options.team)
+      print 'Project %s exists in team %s' % (options.project, t.name)
     sys.exit(1)
 
   # the project doesn't exist.  Create it!
@@ -87,18 +87,17 @@ def main():
 
   # create a static file containing this application's DSN
   k = ProjectKey.objects.get(project_id=p.id).get_dsn()
-  if options.organization == '<%= @organization %>' and options.team == '<%= @team %>':
-    subdir = ''
-  else:
+  prefix = ''
+  if options.organization != '<%= @organization %>' or options.team != '<%= @team %>':
     # this project does not live in the default org+team, so create the
-    # DSN file in a url-encoded directory of "organization/team"
-    subdir = quote(o.name + "/" + t.name + "/")
-  dsn = open('<%= @path %>/dsn/' + subdir + p.name, 'a')
+    # DSN file with a url-encoded prefix of "organization-team-"
+    prefix = quote(o.name.lower() + "-" + t.name.lower() + "-")
+  dsn = open('<%= @path %>/dsn/' + prefix + p.name, 'a')
   dsn.write(k)
   dsn.close()
 
   if options.verbose:
-    print "Project %s created in team %s." % (options.project, options.team)
+    print "Project %s created in team %s." % (options.project, t.name)
 
 if __name__ == "__main__":
   main()

--- a/templates/create_project.py.erb
+++ b/templates/create_project.py.erb
@@ -47,7 +47,7 @@ def main():
   # try to load the requested team
   try:
     t = Team.objects.get(name=options.team,organization_id=o.id)
-  except:
+  except Team.DoesNotExist:
     # this team does not yet exist.  Create it.
     t = Team()
     t.name = options.team

--- a/templates/create_project.py.erb
+++ b/templates/create_project.py.erb
@@ -4,6 +4,7 @@
 #
 import os, sys, site
 from optparse import OptionParser
+from urllib import quote
 
 site.addsitedir('<%= @path %>')
 os.environ['SENTRY_CONF'] = '<%= @path %>/sentry.conf'
@@ -31,25 +32,39 @@ def main():
   if not options.platform:
     parser.error("Platform is required")
 
+  # try to load the requested organization
+  # and the admin user, who will own all new projects and teams
   e = False
   try:  
     o = Organization.objects.get(name=options.org)
-    t = Team.objects.get(name=options.team)
+    u = User.objects.get(email='<%= @admin_email %>')
   except:
     e = sys.exc_info()[0]
-
   if e:
     print "Error loading Sentry environment: %s" % (e)
     sys.exit(1)
 
+  # try to load the requested team
   try:
-    p = Project.objects.get(name=options.project)
+    t = Team.objects.get(name=options.team)
+  except:
+    # this team does not yet exist.  Create it.
+    t = Team()
+    t.name = options.team
+    t.organization_id = o.id
+    t.owner_id = u.id
+    t.save()
+    # reload the object
+    t = Team.objects.get(name=options.team)
+
+  try:
+    p = Project.objects.get(name=options.project,team_id=t.id)
   except:
     p = False
 
   if p:
     if options.verbose:
-      print 'Project exists: %s' % (options.project)
+      print 'Project %s exists in team %s' % (options.project, options.team)
     sys.exit(1)
 
   # the project doesn't exist.  Create it!
@@ -72,12 +87,18 @@ def main():
 
   # create a static file containing this application's DSN
   k = ProjectKey.objects.get(project_id=p.id).get_dsn()
-  dsn = open('<%= @path %>/dsn/' + p.name, 'a')
+  if options.organization == '<%= @organization %>' and options.team == '<%= @team %>':
+    subdir = ''
+  else:
+    # this project does not live in the default org+team, so create the
+    # DSN file in a url-encoded directory of "organization/team"
+    subdir = quote(o.name + "/" + t.name + "/")
+  dsn = open('<%= @path %>/dsn/' + subdir + p.name, 'a')
   dsn.write(k)
   dsn.close()
 
   if options.verbose:
-    print "Project %s created." % (options.project)
+    print "Project %s created in team %s." % (options.project, options.team)
 
 if __name__ == "__main__":
   main()

--- a/templates/dsn_mapper.py.erb
+++ b/templates/dsn_mapper.py.erb
@@ -1,4 +1,5 @@
 import os, sys, site
+from urllib import quote
 
 site.addsitedir('<%= @path %>')
 os.environ['SENTRY_CONF'] = '<%= @path %>/sentry.conf'
@@ -6,12 +7,20 @@ os.environ['SENTRY_CONF'] = '<%= @path %>/sentry.conf'
 # Check to see if the project exists on the team
 from sentry.utils.runner import configure
 configure()
-from sentry.models import Project, ProjectKey
+from sentry.models import Organization, Team, Project, ProjectKey
+
+# load up the default organization and team
+org = Organization.objects.get(name='<%= @organization %>')
+team = Team.objects.get(name='<%= @team %>',organization_id=org.id)
 
 for project in Project.objects.all():
   doit = False
   if project.id and (not project.is_internal_project()):
-    dsn_file = '<%= @path %>/dsn/' + project.name.lower()
+    if (project.organization_id == org.id) and (project.team_id == team.id):
+      prefix = ''
+    else:
+      prefix = quote(project.organization.name.lower() + "-" + project.team.name.lower() + "-")
+    dsn_file = '<%= @path %>/dsn/' + prefix + project.name.lower()
     try:
       dsn = ProjectKey.objects.get(project_id=project.id).get_dsn()
     except:

--- a/templates/dsn_mapper.py.erb
+++ b/templates/dsn_mapper.py.erb
@@ -7,19 +7,12 @@ os.environ['SENTRY_CONF'] = '<%= @path %>/sentry.conf'
 # Check to see if the project exists on the team
 from sentry.utils.runner import configure
 configure()
-from sentry.models import Organization, Team, Project, ProjectKey
-
-# load up the default organization and team
-org = Organization.objects.get(name='<%= @organization %>')
-team = Team.objects.get(name='<%= @team %>',organization_id=org.id)
+from sentry.models import Project, ProjectKey
 
 for project in Project.objects.all():
   doit = False
   if project.id and (not project.is_internal_project()):
-    if (project.organization_id == org.id) and (project.team_id == team.id):
-      prefix = ''
-    else:
-      prefix = quote(project.organization.name.lower() + "-" + project.team.name.lower() + "-")
+    prefix = quote(project.organization.name.lower() + "-" + project.team.name.lower() + "-")
     dsn_file = '<%= @path %>/dsn/' + prefix + project.name.lower()
     try:
       dsn = ProjectKey.objects.get(project_id=project.id).get_dsn()


### PR DESCRIPTION
The create_project.py script had previously accepted a `-t` flag to
specify the team to which the project should be assigned. This commit
allows create_project.py to create that team if it does not exist.

Note that the `-o` flag allows the specification of an organization, but
the script **does not** create new organizations at this time.

The `sentry::source::export` and `sentry::source::project` defined types
have been updated to pass organization and team.

For projects created outside of the default organization+team combo, the
DSN cache file will include the organization and team in the directory
name. These values are `uriescape()`d to ensure that spaces and other
things are supported.

Closes #11
