### PR TITLE
Added support for sentry extension installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,8 @@
 #
 # wsgi_*: mod_wsgi controls
 #
+# extensions: array of sentry extensions to install (sentry-github)
+#
 # === Authors
 # Dan Sajner <dsajner@covermymeds.com>
 # Scott Merrill <smerrill@covermymeds.com>
@@ -113,6 +115,7 @@ class sentry (
   $vhost             = $sentry::params::vhost,
   $wsgi_processes    = $sentry::params::wsgi_processes,
   $wsgi_threads      = $sentry::params::wsgi_threads,
+  $extensions        = $sentry::params::extensions,
 ) inherits ::sentry::params {
 
   # Install Sentry
@@ -127,6 +130,7 @@ class sentry (
     team              => $team,
     user              => $user,
     version           => $version,
+    extensions        => $extensions,
   }
 
   file { "${path}/sentry.conf":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -122,6 +122,7 @@ class sentry::install (
 
   # Install any extensions we might have been given. We install these
   # *after* Sentry to ensure the correct version of Sentry is installed
+  validate_array($extensions)
   $extensions.each |String $extension| {
     python::pip { $extension:
       require => Python::Pip['sentry'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,6 +35,7 @@ class sentry::install (
   $team              = $sentry::team,
   $user              = $sentry::user,
   $version           = $sentry::version,
+  $extensions        = $sentry::extensions,
 ) {
 
   group { $group:
@@ -117,6 +118,14 @@ class sentry::install (
   python::pip { 'sentry-ldap-auth':
     ensure  => $ldap_auth_version,
     require => Python::Pip['sentry'],
+  }
+
+  # Install any extensions we might have been given. We install these
+  # *after* Sentry to ensure the correct version of Sentry is installed
+  $extensions.each |String $extension| {
+    python::pip { $extension:
+      require => Python::Pip['sentry'],
+    }
   }
 
   # this exec will handle creating a new database, as well as upgrading

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,4 +41,5 @@ class sentry::params {
   $vhost             = $::fqdn
   $wsgi_processes    = 1
   $wsgi_threads      = 15
+  $extensions        = []
 }


### PR DESCRIPTION
Added some basic support for arbitrary extension installation. This will allow extensions to be added during sentry installation or post-installation.
