### PR TITLE
Version 3

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,9 @@
+fixtures:
+  symlinks:
+    sentry: "#{source_dir}"
+  forge_modules:
+    apache: "puppetlabs/apache"
+    concat: "puppetlabs/concat"
+    logrotate: "yo61/logrotate"
+    python: "stankevich/python"
+    stdlib: "puppetlabs/stdlib"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
 - better bootstrap on very first install
 - make default team the same name as the default organization
 - only support Sentry versions 8.4.0 and up, due to changes to Sentry code
-initial spec test
+- initial spec test
 * Fri Feb 26 2016 Dan Sajner <dsajner@covermymeds.com) - 2.0.0
 - BREAKING CHANGE - Add support for creating custom teams
 - BREAKING CHANGE - Require Puppet >= 4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Thu Jun 02 2016 Scott Merrill <smerrill@covermymeds.com> - 3.0.0
+- add new sentry::config and sentry::setup classes
+- make all sub-classes private
+- better manage class containment and ordering (Closes #22)
+- restart background services after upgrade (Closes #21)
+- better bootstrap on very first install
+- make default team the same name as the default organization
+- only support Sentry versions 8.4.0 and up, due to changes to Sentry code
+initial spec test
 * Fri Feb 26 2016 Dan Sajner <dsajner@covermymeds.com) - 2.0.0
 - BREAKING CHANGE - Add support for creating custom teams
 - BREAKING CHANGE - Require Puppet >= 4

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://gems.covermymeds.com"
+source "https://rubygems.org"
 gem "rspec"
 gem "json_pure"
 gem "hiera", ">= 2.0", "< 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://gems.covermymeds.com"
+gem "rspec"
+gem "json_pure"
+gem "hiera", ">= 2.0", "< 4.0"
+gem "puppet", ">= 4"
+gem "rspec-puppet", ">= 2.4"
+gem "puppetlabs_spec_helper"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ puppet-sentry
 
 [Sentry](https://www.getsentry.com) is "a modern error logging and aggregation platform."  This module installs the [on-premise](https://docs.getsentry.com/on-premise/) open source version of Sentry. A Sentry administrative user, default Organization and default Team will be created.
 
+**NOTE** version 3 of this module only supports Sentry versions 8.4.0 and above.
+
 ## Dependencies
 This module supports only Red Hat Enterprise Linux 7 and its derivatives.
 
@@ -108,7 +110,7 @@ Class parameters:
 * **redis_port**: port to use for Redis (6379)
 * **secret_key**: string used to hash cookies (fqdn_rand_string(40))
 * **smtp_host**: name or IP of SMTP server (localhost)
-* **ssl_* **: Apache SSL controls.  The `ssl_cert` and `ssl_key` parameters reference files on the Sentry server.  You are responsible for getting these files onto the server yourself.
+* **ssl_* **: Apache SSL controls.  The `ssl_cert` and `ssl_key` parameters reference files on the Sentry server. Your Sentry profile class or other higher level class should manage the installation of these file resources.
 * **url**: source URL form which to install Sentry (false, use [PyPI](https://pypi.python.org/pypi/sentry/))
 * **user**: UNIX user to own virtualenv, and run background workers (sentry)
 * **version**: the Sentry version to install

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'rspec-puppet/rake_task'
+require 'puppetlabs_spec_helper/rake_tasks'
+
+begin
+  if Gem::Specification::find_by_name('puppet-lint')
+    require 'puppet-lint/tasks/puppet-lint'
+    PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "vendor/**/*.pp"]
+    task :default => [:rspec, :lint]
+  end
+rescue Gem::LoadError
+  task :default => :rspec
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,46 @@
+class sentry::config (
+  $admin_email       = $sentry::admin_email,
+  $admin_password    = $sentry::admin_password,
+  $custom_config     = $sentry::custom_conifg,
+  $custom_settings   = $sentry::custom_settings,
+  $db_host           = $sentry::db_host,
+  $db_name           = $sentry::db_name,
+  $db_password       = $sentry::db_password,
+  $db_port           = $sentry::db_port,
+  $db_user           = $sentry::db_user,
+  $group             = $sentry::group,
+  $ldap_base_ou      = $sentry::ldap_base_ou,
+  $ldap_domain       = $sentry::ldap_domain,
+  $ldap_group_base   = $sentry::ldap_group_base,
+  $ldap_group_dn     = $sentry::ldap_group_dn,
+  $ldap_host         = $sentry::ldap_host,
+  $ldap_user         = $sentry::ldap_user,
+  $ldap_password     = $sentry::ldap_password,
+  $memcached_host    = $sentry::memcached_host,
+  $memcached_port    = $sentry::memcached_port,
+  $organization      = $sentrt::organization,
+  $path              = $sentry::path,
+  $redis_host        = $sentry::redis_host,
+  $redis_port        = $sentry::redis_port,
+  $secret_key        = $sentry::secret_key,
+  $smtp_host         = $sentry::smtp_host,
+  $user              = $sentry::user,
+) {
+  assert_private()
+
+  file { "${path}/sentry.conf.py":
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    content => template('sentry/sentry.conf.py.erb'),
+  }
+
+  file { "${path}/config.yml":
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    content => template('sentry/config.yml.erb'),
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,7 @@ class sentry::config (
   $ldap_password     = $sentry::ldap_password,
   $memcached_host    = $sentry::memcached_host,
   $memcached_port    = $sentry::memcached_port,
-  $organization      = $sentrt::organization,
+  $organization      = $sentry::organization,
   $path              = $sentry::path,
   $redis_host        = $sentry::redis_host,
   $redis_port        = $sentry::redis_port,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,11 @@ class sentry (
   $wsgi_threads      = $sentry::params::wsgi_threads,
 ) inherits ::sentry::params {
 
+  if $version != 'latest' {
+    if versioncmp('8.4.0', $version) > 0 {
+      fail('Sentry version 8.4.0 or greater is required.')
+    }
+  }
   class { '::sentry::setup':
     group => $group,
     path  => $path,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,8 +48,6 @@
 #
 # ssl_*: Apache SSL controls
 #
-# team: name of the default team to create and use for new projects
-#
 # url: source URL from which to install Sentry.  (false, use PyPI)
 #
 # user: UNIX user to own virtualenv, and run background workers (sentry)
@@ -104,7 +102,6 @@ class sentry (
   $ssl_chain         = $sentry::params::ssl_chain,
   $ssl_cert          = $sentry::params::ssl_cert,
   $ssl_key           = $sentry::params::ssl_key,
-  $team              = $sentry::params::team,
   $url               = $sentry::params::url,
   $user              = $sentry::params::user,
   $version           = $sentry::params::version,
@@ -161,7 +158,6 @@ class sentry (
     path              => $path,
     project           => $project,
     ldap_auth_version => $ldap_auth_version,
-    team              => $team,
     user              => $user,
     version           => $version,
     subscribe         => Class['::sentry::config'],
@@ -187,7 +183,7 @@ class sentry (
     user      => $user,
     group     => $group,
     path      => $path,
-    subscribe => Class['::sentry::config'],
+    subscribe => Class['::sentry::install'],
   }
   contain '::sentry::service'
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,75 +40,12 @@ class sentry::install (
   $user              = $sentry::user,
   $version           = $sentry::version,
 ) {
-
-  group { $group:
-    ensure => present,
-  }
-
-  user { $user:
-    ensure  => present,
-    gid     => $group,
-    home    => '/dev/null',
-    shell   => '/bin/false',
-    require => Group[$group],
-  }
-
-  file { '/var/log/sentry':
-    ensure  => directory,
-    owner   => 'sentry',
-    group   => 'sentry',
-    mode    => '0755',
-    require => User[$user],
-  }
-
-  # Setup log rotation for the sentry-worker process
-  logrotate::rule { 'sentry-worker':
-    ensure       => present,
-    path         => '/var/log/sentry/sentry-worker.log',
-    create       => true,
-    compress     => true,
-    missingok    => true,
-    rotate       => 14,
-    ifempty      => false,
-    create_mode  => '0644',
-    create_owner => $user,
-    create_group => $group,
-  }
-
-  $rpm_dependencies = [
-    'libffi-devel',
-    'libxml2-devel',
-    'libxslt-devel',
-    'openldap-devel',
-    'openssl-devel',
-    'zlib-devel',
-  ]
-
-  ensure_packages( $rpm_dependencies )
-
-  python::virtualenv { $path:
-    ensure  => present,
-    owner   => $user,
-    group   => $group,
-    version => 'system',
-  }
+  assert_private()
 
   Python::Pip {
     ensure     => present,
     virtualenv => $path,
   }
-
-  $pip_dependencies = [
-    'django-auth-ldap',
-    'hiredis',
-    'nydus',
-    'psycopg2',
-    'python-memcached',
-    'python-ldap',
-    'redis',
-  ]
-
-  python::pip { $pip_dependencies: }
 
   python::pip { 'sentry':
     ensure => $version,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,6 @@
 # organization: default Sentry organization to create
 # path: path into which to create virtualenv and install Sentry
 # project: initial Sentry project to create
-# team: default Sentry team to create
 # url: URL from which to install Sentry
 # user: UNIX user to own Sentry files
 # version: version of Sentry to install
@@ -35,7 +34,6 @@ class sentry::install (
   $organization      = $sentry::organization,
   $path              = $sentry::path,
   $project           = $sentry::project,
-  $team              = $sentry::team,
   $url               = $sentry::url,
   $user              = $sentry::user,
   $version           = $sentry::version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,6 @@ class sentry::params {
   $ssl_chain         = undef
   $ssl_cert          = '/etc/pki/tls/certs/localhost.crt'
   $ssl_key           = '/etc/pki/tls/private/localhost.key'
-  $team              = 'Default'
   $url               = false
   $user              = 'sentry'
   $version           = 'latest'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,7 @@
 # == Class: sentry::service
 #
 # This class is meant to be called from sentry.
-# It ensures the service is running via systemd
+# It ensures the background services are running via systemd
 #
 # === Parameters
 #
@@ -30,6 +30,7 @@ class sentry::service (
     path        => '/bin:/sbin',
   }
 
+  # Sentry Celery Worker
   file { '/etc/systemd/system/sentry-worker.service':
     ensure  => present,
     mode    => '0644',
@@ -56,10 +57,50 @@ class sentry::service (
     subscribe   => Class['::sentry::config'],
   }
 
-  # Setup log rotation for the sentry-worker process
+  # Sentry Celery Beat
+  file { '/etc/systemd/system/sentry-beat.service':
+    ensure  => present,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    content => template('sentry/sentry-beat.service.erb'),
+    notify  => Exec['enable-sentry-services'],
+  }
+
+  service { 'sentry-beat':
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    require    => [ File['/etc/systemd/system/sentry-beat.service'],
+                    User[$user],
+                  ],
+  }
+
+  # if the Sentry config changes, do a full restart of the Sentry beat worker
+  exec { 'restart-sentry-beat':
+    command     => '/usr/bin/systemctl stop sentry-beat; /usr/bin/systemctl start sentry-beat',
+    path        => '/bin:/usr/bin',
+    refreshonly => true,
+    subscribe   => Class['::sentry::config'],
+  }
+
+  # Setup log rotation
   logrotate::rule { 'sentry-worker':
     ensure       => present,
     path         => '/var/log/sentry/sentry-worker.log',
+    create       => true,
+    compress     => true,
+    missingok    => true,
+    rotate       => 14,
+    ifempty      => false,
+    create_mode  => '0644',
+    create_owner => $user,
+    create_group => $group,
+  }
+
+  logrotate::rule { 'sentry-beat':
+    ensure       => present,
+    path         => '/var/log/sentry/sentry-beat.log',
     create       => true,
     compress     => true,
     missingok    => true,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,0 +1,81 @@
+# == Class: sentry::setup
+#
+# Installs Sentry prerequisites
+#
+# === Params
+#
+# group: UNIX group to own Sentry files
+# path: path into which to create virtualenv and install Sentry
+# user: UNIX user to own Sentry files
+#
+# === Authors
+#
+# Scott Merrill <smerrill@covermymeds.com>
+#
+# === Copyright
+#
+# Copyright 2016 CoverMyMeds
+#
+class sentry::setup (
+  $group             = $sentry::group,
+  $path              = $sentry::path,
+  $user              = $sentry::user,
+) {
+  assert_private()
+
+  group { $group:
+    ensure => present,
+  }
+
+  user { $user:
+    ensure  => present,
+    gid     => $group,
+    home    => '/dev/null',
+    shell   => '/bin/false',
+    require => Group[$group],
+  }
+
+  file { '/var/log/sentry':
+    ensure  => directory,
+    owner   => 'sentry',
+    group   => 'sentry',
+    mode    => '0755',
+    require => User[$user],
+  }
+
+  $rpm_dependencies = [
+    'libffi-devel',
+    'libxml2-devel',
+    'libxslt-devel',
+    'openldap-devel',
+    'openssl-devel',
+    'zlib-devel',
+  ]
+
+  ensure_packages( $rpm_dependencies )
+
+  python::virtualenv { $path:
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    version => 'system',
+  }
+
+  Python::Pip {
+    ensure     => present,
+    virtualenv => $path,
+  }
+
+  $pip_dependencies = [
+    'django-auth-ldap',
+    'hiredis',
+    'nydus',
+    'psycopg2',
+    'python-memcached',
+    'python-ldap',
+    'redis',
+  ]
+
+  python::pip { $pip_dependencies: }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-sentry",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "Install and configure Sentry",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+describe 'Sentry' do
+  let(:facts) do
+    {
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '7.2',
+      operatingsystemmajrelease: '7',
+      os: {
+        architecture: "x86_64",
+        family: "RedHat",
+        hardware: "x86_64",
+        name: "RedHat",
+        release: {
+          full: "7.2",
+          major: "7",
+          minor: "2"
+        },
+        selinux: {
+          config_mode: "permissive",
+          config_policy: "targeted",
+          current_mode: "permissive",
+          enabled: true,
+          enforced: false,
+          policy_version: "28"
+        }
+      },
+      python_version: '2.7.5'
+    }
+  end
+  context 'all default values' do
+    it { is_expected.to contain_class('sentry::setup') }
+    it { is_expected.to contain_class('sentry::config') }
+    it { is_expected.to contain_class('sentry::install') }
+    it { is_expected.to contain_class('sentry::service') }
+    it { is_expected.to contain_class('sentry::wsgi') }
+  end
+end

--- a/spec/classes/sentry_spec.rb
+++ b/spec/classes/sentry_spec.rb
@@ -35,4 +35,11 @@ describe 'Sentry' do
     it { is_expected.to contain_class('sentry::service') }
     it { is_expected.to contain_class('sentry::wsgi') }
   end
+
+  context 'Sentry version < 8.4.0' do
+    let (:params) {{ :version => '8.0.0' }}
+    it "should fail" do
+      expect { catalogue }.to raise_error(Puppet::Error, /Sentry version 8.4.0 or greater is required./)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,40 @@
+require 'rspec-puppet/spec_helper'
+require 'puppetlabs_spec_helper/puppetlabs_spec_helper'
+
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+
+RSpec.configure do |c|
+  c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end
+
+shared_context 'RedHat 7' do
+  let(:facts) do
+    {
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '7.2',
+      operatingsystemmajrelease: '7',
+      os: {
+        architecture: "x86_64",
+        family: "RedHat",
+        hardware: "x86_64",
+        name: "RedHat",
+        release: {
+          full: "7.2",
+          major: "7",
+          minor: "2"
+        },
+        selinux: {
+          config_mode: "permissive",
+          config_policy: "targeted",
+          current_mode: "permissive",
+          enabled: true,
+          enforced: false,
+          policy_version: "28"
+        }
+      }
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,33 +8,3 @@ RSpec.configure do |c|
   c.manifest_dir = File.join(fixture_path, 'manifests')
   c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 end
-
-shared_context 'RedHat 7' do
-  let(:facts) do
-    {
-      osfamily: 'RedHat',
-      operatingsystem: 'RedHat',
-      operatingsystemrelease: '7.2',
-      operatingsystemmajrelease: '7',
-      os: {
-        architecture: "x86_64",
-        family: "RedHat",
-        hardware: "x86_64",
-        name: "RedHat",
-        release: {
-          full: "7.2",
-          major: "7",
-          minor: "2"
-        },
-        selinux: {
-          config_mode: "permissive",
-          config_policy: "targeted",
-          current_mode: "permissive",
-          enabled: true,
-          enforced: false,
-          policy_version: "28"
-        }
-      }
-    }
-  end
-end

--- a/templates/bootstrap.py.erb
+++ b/templates/bootstrap.py.erb
@@ -12,6 +12,7 @@ from sentry.utils.runner import configure
 configure()
 
 from sentry.models import Organization, Project, Team, User
+from sentry.models import OrganizationMember, OrganizationMemberTeam
 # The admin user should have been created by Puppet prior to this script running.
 # We explicitly do not create one here so as not to store the admin password
 #    in this script. 
@@ -22,32 +23,28 @@ except:
   # exit with an error.
   sys.exit(1)
 
-# make sure an organization exists
-try:
-  o = Organization.objects.get(name='<%= @organization %>')
-except:
-  o = Organization()
-  o.name  = '<%= @organization %>'
-  o.owner_id = u.id
-  o.save()
+o = Organization()
+o.name  = '<%= @organization %>'
+o.save()
+o.owner_id = u.id
+o.save()
+om = OrganizationMember.objects.create(
+  organization=o,
+  user=u,
+)
 
-try:
-  t = Team.objects.get(name='<%= @team %>')
-except:
-  t = Team()
-  t.name = '<%= @team %>'
-  t.owner_id = u.id
-  t.organization_id = o.id
-  t.save()
+t = o.team_set.create(name=o.name)
+OrganizationMemberTeam.objects.create(
+  team=t,
+  organizationmember=om,
+  is_active=True
+)
 
-try:
-  p = Project.objects.get(name='<%= @project %>')
-except:
-  p = Project()
-  p.name = '<%= @project %>'
-  p.organization_id = o.id
-  p.team_id = t.id
-  p.save()
+p = Project()
+p.name = '<%= @project %>'
+p.organization_id = o.id
+p.team_id = t.id
+p.save()
 
 # Write the log only after everything has executed successfully,
 # because Puppet relies on the presence of the log file to continue
@@ -55,7 +52,7 @@ except:
 log = open('<%= @path %>/bootstrap.log', 'a')
 log.write('Sentry version <%= @version %> bootstrap...')
 log.write('Organization <%= @organization %> created.')
-log.write('Team <%= @team %> created.')
+log.write('Team <%= @organization %> created.')
 log.write('Project <%= @project %> created.')
 log.close()
 

--- a/templates/sentry-beat.service.erb
+++ b/templates/sentry-beat.service.erb
@@ -1,0 +1,18 @@
+[Unit]
+Description=Sentry Beat
+After=network.target
+
+[Service]
+User=<%= @user %>
+Group=<%= @group %>
+Type=simple
+PIDFile=<%= @path %>/sentry-beat.pid
+Environment=VIRTUAL_ENV="<%= @path %>"
+Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
+WorkingDirectory=<%= @path %>
+ExecStart=<%= @path %>/bin/sentry --config=<%= @path %> celery beat -f /var/log/sentry/sentry-beat.log --pidfile=<%= @path %>/sentry-beat.pid
+ExecStop=/bin/kill -KILL $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/sentry-worker.service.erb
+++ b/templates/sentry-worker.service.erb
@@ -10,7 +10,7 @@ PIDFile=<%= @path %>/sentry-worker.pid
 Environment=VIRTUAL_ENV="<%= @path %>"
 Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
 WorkingDirectory=<%= @path %>
-ExecStart=<%= @path %>/bin/sentry --config=<%= @path %> celery worker -B -f /var/log/sentry/sentry-worker.log --pidfile=/<%= @path %>/sentry-worker.pid
+ExecStart=<%= @path %>/bin/sentry --config=<%= @path %> celery worker -f /var/log/sentry/sentry-worker.log --pidfile=/<%= @path %>/sentry-worker.pid
 ExecStop=/bin/kill -KILL $MAINPID
 ExecReload=/bin/kill -HUP $MAINPID
 


### PR DESCRIPTION
This is a pretty big reworking to account for on-going Sentry development.

The biggest changes are:
- add new `sentry::config` and `sentry::setup` classes
- make all sub-classes private
- better manage class containment and ordering (Closes #22)
- restart background services after upgrade (Closes #21) 
- better bootstrap on very first install
- make default team the same name as the default organization
- initial spec test -- much more to come!

Due to changes in the upstream Sentry code and how it handles configuration, this module will not be able to install older versions of Sentry.  The default version to install is `latest`, which at this time is [8.4.1](https://pypi.python.org/pypi/sentry/8.4.1).  Arbitrary versions can be installed, but I have only tested it with [8.4.0].

Upgrades from older version of Sentry managed by older versions of this module should work just fine, provided both happen in tandem.  That is to say: using puppet-sentry 2.0.1 with Sentry 8.0.0, you can upgrade to puppet-sentry 3.0.0 and Sentry 8.4.1 simultaneously.  Other combinations have not been tested at this time.
