### PR TITLE
 Added libjpeg package to rpm_dependencies

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -45,6 +45,7 @@ class sentry::setup (
 
   $rpm_dependencies = [
     'libffi-devel',
+    'libjpeg-turbo-devel',
     'libxml2-devel',
     'libxslt-devel',
     'openldap-devel',


### PR DESCRIPTION
This addresses https://github.com/covermymeds/puppet-sentry/issues/27

Would this be adequate or should we conditionally install it if we're installing sentry version 8.5.0 or greater?
