### PR TITLE
Allow using pip for extension installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,8 +63,14 @@ class sentry::install (
   # *after* Sentry to ensure the correct version of Sentry is installed
   validate_hash($extensions)
   $extensions.each |String $extension, String $url| {
+    # If url is the string 'false', use pip.
+    $source = $url ? {
+      'false'  => false,
+      default  => $url,
+    }
+
     python::pip { $extension:
-      url     => $url,
+      url     => $source,
       require => Python::Pip['sentry'],
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,6 @@
     { "name": "puppetlabs/apache", "version_requirement": ">= 1.5.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0" },
     { "name": "stankevich/python", "version_requirement": ">= 1.9.8" },
-    { "name": "yo61/logrotate", "version_requirement:" ">= 1.3.0" }
+    { "name": "yo61/logrotate", "version_requirement": ">= 1.3.0" }
   ]
 }


### PR DESCRIPTION
Fixes:

 Warning: sentry has an invalid and unparsable metadata.json file. The parse error: 399: unexpected token at '{ "name": "yo61/logrotate", "version_requirement:" ">= 1.3.0" }  ]


Also allowing to pass false as an extension's url. This lets python::pip just use pip default.