### PR TITLE
sentry beat was deprecated in 8.5.0 for run cron

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,8 +127,8 @@ class sentry (
 ) inherits ::sentry::params {
 
   if $version != 'latest' {
-    if versioncmp('8.4.0', $version) > 0 {
-      fail('Sentry version 8.4.0 or greater is required.')
+    if versioncmp('8.5.0', $version) > 0 {
+      fail('Sentry version 8.5.0 or greater is required.')
     }
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -57,28 +57,34 @@ class sentry::service (
     subscribe   => Class['::sentry::config'],
   }
 
-  # Sentry Celery Beat
+  # beat no longer exists
   file { '/etc/systemd/system/sentry-beat.service':
+    ensure => absent,
+    notify => Exec['enable-sentry-services'],
+  }
+
+  # Sentry Cron
+  file { '/etc/systemd/system/sentry-cron.service':
     ensure  => present,
     mode    => '0644',
     owner   => 'root',
     group   => 'root',
-    content => template('sentry/sentry-beat.service.erb'),
+    content => template('sentry/sentry-cron.service.erb'),
     notify  => Exec['enable-sentry-services'],
   }
 
-  service { 'sentry-beat':
+  service { 'sentry-cron':
     ensure     => running,
     enable     => true,
     hasrestart => true,
-    require    => [ File['/etc/systemd/system/sentry-beat.service'],
+    require    => [ File['/etc/systemd/system/sentry-cron.service'],
                     User[$user],
                   ],
   }
 
-  # if the Sentry config changes, do a full restart of the Sentry beat worker
-  exec { 'restart-sentry-beat':
-    command     => '/usr/bin/systemctl stop sentry-beat; /usr/bin/systemctl start sentry-beat',
+  # if the Sentry config changes, do a full restart of the Sentry cron worker
+  exec { 'restart-sentry-cron':
+    command     => '/usr/bin/systemctl stop sentry-cron; /usr/bin/systemctl start sentry-cron',
     path        => '/bin:/usr/bin',
     refreshonly => true,
     subscribe   => Class['::sentry::config'],
@@ -98,9 +104,9 @@ class sentry::service (
     create_group => $group,
   }
 
-  logrotate::rule { 'sentry-beat':
+  logrotate::rule { 'sentry-cron':
     ensure       => present,
-    path         => '/var/log/sentry/sentry-beat.log',
+    path         => '/var/log/sentry/sentry-cron.log',
     create       => true,
     compress     => true,
     missingok    => true,

--- a/templates/sentry-cron.service.erb
+++ b/templates/sentry-cron.service.erb
@@ -1,16 +1,16 @@
 [Unit]
-Description=Sentry Beat
+Description=Sentry Cron
 After=network.target
 
 [Service]
 User=<%= @user %>
 Group=<%= @group %>
 Type=simple
-PIDFile=<%= @path %>/sentry-beat.pid
+PIDFile=<%= @path %>/sentry-cron.pid
 Environment=VIRTUAL_ENV="<%= @path %>"
 Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
 WorkingDirectory=<%= @path %>
-ExecStart=<%= @path %>/bin/sentry --config=<%= @path %> celery beat -f /var/log/sentry/sentry-beat.log --pidfile=<%= @path %>/sentry-beat.pid
+ExecStart=<%= @path %>/bin/sentry --config=<%= @path %> run cron -f /var/log/sentry/sentry-cron.log --pidfile=<%= @path %>/sentry-cron.pid
 ExecStop=/bin/kill -KILL $MAINPID
 ExecReload=/bin/kill -HUP $MAINPID
 


### PR DESCRIPTION
Bump minimum version to 8.5.0, remove the beat service and install/manage the cron service.