### PR TITLE
migrate filestore configuration for 8.10.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,8 +115,8 @@ class sentry (
 ) inherits ::sentry::params {
 
   if $version != 'latest' {
-    if versioncmp('8.5.0', $version) > 0 {
-      fail('Sentry version 8.5.0 or greater is required.')
+    if versioncmp('8.10.0', $version) > 0 {
+      fail('Sentry version 8.10.0 or greater is required.')
     }
   }
 

--- a/templates/config.yml.erb
+++ b/templates/config.yml.erb
@@ -5,6 +5,9 @@
 
 # If this file ever becomes compromised, it's important to regenerate your SECRET_KEY
 # Changing this value will result in all current sessions being invalidated
+filestore.backend: 'django.core.files.storage.FileSystemStorage'
+filestore.options:
+  location: '/tmp/sentry-files'
 system.url-prefix: '<%= @_url_prefix %>'
 system.secret-key: '<%= @secret_key %>'
 system.admin-email: '<%= @admin_email %>'

--- a/templates/sentry.conf.py.erb
+++ b/templates/sentry.conf.py.erb
@@ -124,18 +124,6 @@ SENTRY_TSDB = 'sentry.tsdb.redis.RedisTSDB'
 SENTRY_DIGESTS = 'sentry.digests.backends.redis.RedisBackend'
 
 ################
-# File storage #
-################
-
-# Any Django storage backend is compatible with Sentry. For more solutions see
-# the django-storages package: https://django-storages.readthedocs.org/en/latest/
-
-SENTRY_FILESTORE = 'django.core.files.storage.FileSystemStorage'
-SENTRY_FILESTORE_OPTIONS = {
-    'location': '/tmp/sentry-files',
-}
-
-################
 ## Web Server ##
 ################
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/blob/c0009e6f9e759439c70b3a163012de46bcf8dcba/CHANGES#L244-L245

This updates our module for 8.10 and above, making it the required version.

As of 8.15, the deprecated option is still supported, **so upgrade, then merge this**.