### PR TITLE
add an option for disabling db bootstrap and update documentation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,73 +2,6 @@
 #
 # Install Sentry from PyPI and configure an Apache mod_wsgi vhost
 #
-# === Parameters
-#
-# admin_email: the admin user's email address; also used as login name (root@localhost)
-#
-# admin_password: the admin user's password (admin)
-#
-# custom_config: array of custom configs to put into config.yml (undef)
-#
-# custom_settings: arrray of custom settings to put into sentry.conf.py (undef)
-#
-# db_host: the PostgreSQL database host (localhost)
-#
-# db_name: the name of the PostgreSQL database to use (sentry)
-#
-# db_password: the DB user's password (sentry)
-#
-# db_port: the PostgreSQL database port (5432)
-#
-# db_user: the user account with which to connect to the database (sentry)
-#
-# extensions: hash of sentry extensions and source URL to install (sentry-github)
-#
-# group: UNIX group to own virtualenv, and run background workers (sentry)
-#
-# ldap_auth_version: version of the sentry_ldap_auth Python module to install (present)
-#
-# ldap_*: LDAP connection details used for creating local user accounts from AD users
-#
-# memcached_host: name or IP of memcached server (localhost)
-#
-# memcached_port: port to use for memcached (11211)
-#
-# metrics_enable: whether to enable the sentry metrics (false)
-#
-# metrics_backend: which metrics backend to enable (statsd)
-#
-# organization: default organization to create, and in which to create new users
-#
-# path: path into which to install Sentry, and create the virtualenv (/srv/sentry)
-#
-# redis_host: name or IP of Redis server (localhost)
-#
-# redis_port: port to use for Redis (6379)
-#
-# secret_key: string used to hash cookies (fqdn_rand_string(40))
-#
-# smtp_host: name or IP of SMTP server (localhost)
-#
-# ssl_*: Apache SSL controls
-#
-# statsd_host: hostname of statsd server (localhost)
-#
-# statsd_port: port for statsd server (8125)
-#
-# url: source URL from which to install Sentry.  (false, use PyPI)
-#
-# user: UNIX user to own virtualenv, and run background workers (sentry)
-#
-# version: the Sentry version to install
-#
-# vhost: the URL at which users will access the Sentry GUI
-#
-# wsgi_*: mod_wsgi controls
-#
-# worker_concurrency: number of concurrent workers (processors.count)
-#
-#
 # === Authors
 # Dan Sajner <dsajner@covermymeds.com>
 # Scott Merrill <smerrill@covermymeds.com>
@@ -79,9 +12,58 @@
 # === License
 # Released under the terms of the MIT license.  See LICENSE for more details
 #
+# === Params
+#
+# @param admin_email the admin user's email address; also used as login name (root@localhost)
+# @param admin_password the admin user's password (admin)
+# @param bootstrap Whether this node will bootstrap the database, admin, etc
+# @param custom_config array of custom configs to put into config.yml (undef)
+# @param custom_settings arrray of custom settings to put into sentry.conf.py (undef)
+# @param db_host the PostgreSQL database host (localhost)
+# @param db_name the name of the PostgreSQL database to use (sentry)
+# @param db_password the DB user's password (sentry)
+# @param db_port the PostgreSQL database port (5432)
+# @param db_user the user account with which to connect to the database (sentry)
+# @param email_from Email address sentry emails will come from
+# @param extensions hash of sentry extensions and source URL to install (sentry-github)
+# @param group UNIX group to own virtualenv, and run background workers (sentry)
+# @param ldap_auth_version version of the sentry_ldap_auth Python module to install (present)
+# @param ldap_base_ou LDAP connection details used for creating local user accounts from AD users
+# @param ldap_domain LDAP connection details used for creating local user accounts from AD users
+# @param ldap_group_base LDAP connection details used for creating local user accounts from AD users
+# @param ldap_group_dn LDAP connection details used for creating local user accounts from AD users
+# @param ldap_host LDAP connection details used for creating local user accounts from AD users
+# @param ldap_user LDAP bind user
+# @param ldap_password LDAP bind password
+# @param memcached_host name or IP of memcached server (localhost)
+# @param memcached_port port to use for memcached (11211)
+# @param metrics_enable whether to enable the sentry metrics (false)
+# @param metrics_backend which metrics backend to enable (statsd)
+# @param organization default organization to create, and in which to create new users
+# @param path path into which to install Sentry, and create the virtualenv (/srv/sentry)
+# @param project Default project name
+# @param redis_host name or IP of Redis server (localhost)
+# @param redis_port port to use for Redis (6379)
+# @param secret_key string used to hash cookies (fqdn_rand_string(40))
+# @param smtp_host name or IP of SMTP server (localhost)
+# @param ssl_ca Apache SSL CA cert
+# @param ssl_chain Apache SSL Intermediate CA cert
+# @param ssl_cert Apache SSL public cert
+# @param ssl_key Apache SSL private key
+# @param statsd_host hostname of statsd server (localhost)
+# @param statsd_port port for statsd server (8125)
+# @param url source URL from which to install Sentry.  (false, use PyPI)
+# @param user UNIX user to own virtualenv, and run background workers (sentry)
+# @param version the Sentry version to install
+# @param vhost the URL at which users will access the Sentry GUI
+# @param wsgi_processes mod_wsgi processes
+# @param wsgi_threads mod_wsgi threads
+# @param worker_concurrency number of concurrent workers (processors.count)
+#
 class sentry (
   $admin_email        = $sentry::params::admin_email,
   $admin_password     = $sentry::params::admin_password,
+  Boolean $bootstrap  = $sentry::params::bootstrap,
   $custom_config      = $sentry::params::custom_conifg,
   $custom_settings    = $sentry::params::custom_settings,
   $db_host            = $sentry::params::db_host,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,20 +2,6 @@
 #
 # Installs Sentry from pip into a virtualenv
 #
-# === Params
-#
-# admin_email: Sentry admin user email address
-# admin_password: Sentry admin user password
-# extensions: hash of sentry extensions and source URL to install
-# group: UNIX group to own Sentry files
-# ldap_auth_version: version of the sentry-ldap-auth plugin to install
-# organization: default Sentry organization to create
-# path: path into which to create virtualenv and install Sentry
-# project: initial Sentry project to create
-# url: URL from which to install Sentry
-# user: UNIX user to own Sentry files
-# version: version of Sentry to install
-#
 # === Authors
 #
 # Dan Sajner <dsajner@covermymeds.com>
@@ -25,9 +11,25 @@
 #
 # Copyright 2015 CoverMyMeds
 #
+# === Params
+#
+# @param admin_email Sentry admin user email address
+# @param admin_password Sentry admin user password
+# @param bootstrap Should this node bootstrap the database
+# @param extensions hash of sentry extensions and source URL to install
+# @param group UNIX group to own Sentry files
+# @param ldap_auth_version version of the sentry-ldap-auth plugin to install
+# @param organization default Sentry organization to create
+# @param path path into which to create virtualenv and install Sentry
+# @param project initial Sentry project to create
+# @param url URL from which to install Sentry
+# @param user UNIX user to own Sentry files
+# @param version version of Sentry to install
+#
 class sentry::install (
   $admin_email       = $sentry::admin_email,
   $admin_password    = $sentry::admin_password,
+  $bootstrap         = $sentry::bootstrap,
   $extensions        = $sentry::extensions,
   $group             = $sentry::group,
   $ldap_auth_version = $sentry::ldap_auth_version,
@@ -69,50 +71,51 @@ class sentry::install (
     }
   }
 
-  # this exec will handle creating a new database, as well as upgrading
-  # an existing database.  The `creates` parameter is version-specific,
-  # so this should run automatically on version upgrades.
-  exec { 'sentry-database-install':
-    command => "${path}/bin/sentry --config=${path} upgrade --noinput > ${path}/install-${version}.log 2>&1",
-    creates => "${path}/install-${version}.log",
-    path    => "${path}/bin:/bin:/usr/bin",
-    user    => $user,
-    group   => $group,
-    cwd     => $path,
-    require => [ Python::Pip['sentry'], User[$user], ],
-  }
+  if $bootstrap {
+    # this exec will handle creating a new database, as well as upgrading
+    # an existing database.  The `creates` parameter is version-specific,
+    # so this should run automatically on version upgrades.
+    exec { 'sentry-database-install':
+      command => "${path}/bin/sentry --config=${path} upgrade --noinput > ${path}/install-${version}.log 2>&1",
+      creates => "${path}/install-${version}.log",
+      path    => "${path}/bin:/bin:/usr/bin",
+      user    => $user,
+      group   => $group,
+      cwd     => $path,
+      require => [ Python::Pip['sentry'], User[$user], ],
+    }
 
-  # the `creates` log file is not version-specific, so as to ensure
-  # this only runs once, upon initial installation.
-  # Note: A failure here is catastrophic, and will prevent additional
-  # Sentry configuration.
-  exec { 'sentry-create-admin':
-    command => "${path}/bin/sentry --config=${path} createuser --superuser --email=${admin_email} --password=${admin_password} --no-input > ${path}/admin-${admin_email}.log 2>&1",
-    creates => "${path}/admin-${admin_email}.log",
-    path    => "${path}/bin:/usr/bin:/usr/sbin:/bin",
-    require => Exec['sentry-database-install'],
-  }
+    # the `creates` log file is not version-specific, so as to ensure
+    # this only runs once, upon initial installation.
+    # Note: A failure here is catastrophic, and will prevent additional
+    # Sentry configuration.
+    exec { 'sentry-create-admin':
+      command => "${path}/bin/sentry --config=${path} createuser --superuser --email=${admin_email} --password=${admin_password} --no-input > ${path}/admin-${admin_email}.log 2>&1",
+      creates => "${path}/admin-${admin_email}.log",
+      path    => "${path}/bin:/usr/bin:/usr/sbin:/bin",
+      require => Exec['sentry-database-install'],
+    }
 
-  file { "${path}/bootstrap.py":
-    ensure  => present,
-    mode    => '0744',
-    content => template('sentry/bootstrap.py.erb'),
-    require => Exec['sentry-create-admin'],
-  }
+    file { "${path}/bootstrap.py":
+      ensure  => present,
+      mode    => '0744',
+      content => template('sentry/bootstrap.py.erb'),
+      require => Exec['sentry-create-admin'],
+    }
 
-  exec { 'sentry-bootstrap':
-    command => "${path}/bootstrap.py",
-    creates => "${path}/bootstrap.log",
-    path    => "${path}/bin:/usr/bin/:/usr/sbin:/bin",
-    require => File["${path}/bootstrap.py"],
-  }
+    exec { 'sentry-bootstrap':
+      command => "${path}/bootstrap.py",
+      creates => "${path}/bootstrap.log",
+      path    => "${path}/bin:/usr/bin/:/usr/sbin:/bin",
+      require => File["${path}/bootstrap.py"],
+    }
 
-  file { "${path}/dsn":
-    ensure  => directory,
-    mode    => '0755',
-    owner   => $user,
-    group   => $group,
-    require => File["${path}/bootstrap.py"],
+    file { "${path}/dsn":
+      ensure  => directory,
+      mode    => '0755',
+      owner   => $user,
+      group   => $group,
+      require => File["${path}/bootstrap.py"],
+    }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class sentry::params {
   $admin_email        = 'root@localhost'
   $admin_password     = 'admin'
   $admin_user         = 'admin'
+  $bootstrap          = true
   $custom_config      = undef
   $custom_settings    = undef
   $db_host            = 'localhost'


### PR DESCRIPTION
Allow disabling bootstrap on nodes, so that they can be used as secondary nodes in an existing Sentry environment. 

Also reworked the documentation using puppet-strings formatting.