### PR TITLE
Write url-prefix config option to config.yml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,9 +29,16 @@ class sentry::config (
   $smtp_host         = $sentry::smtp_host,
   $statsd_host       = $sentry::statsd_host,
   $statsd_port       = $sentry::statsd_port,
+  $url_prefix        = $sentry::url_prefix,
   $user              = $sentry::user,
 ) {
   assert_private()
+
+  if $url_prefix {
+    $_url_prefix = $url_prefix
+  } else {
+    $_url_prefix = "https://${sentry::vhost}"
+  }
 
   file { "${path}/sentry.conf.py":
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@
 # @param url source URL from which to install Sentry.  (false, use PyPI)
 # @param user UNIX user to own virtualenv, and run background workers (sentry)
 # @param version the Sentry version to install
+# @param url_prefix Sentry URL for error reporting, used when generating DSN files
 # @param vhost the URL at which users will access the Sentry GUI
 # @param wsgi_processes mod_wsgi processes
 # @param wsgi_threads mod_wsgi threads
@@ -102,6 +103,7 @@ class sentry (
   $url                = $sentry::params::url,
   $user               = $sentry::params::user,
   $version            = $sentry::params::version,
+  Variant[Undef,String] $url_prefix  = undef,
   $vhost              = $sentry::params::vhost,
   $wsgi_processes     = $sentry::params::wsgi_processes,
   $wsgi_threads       = $sentry::params::wsgi_threads,

--- a/templates/config.yml.erb
+++ b/templates/config.yml.erb
@@ -5,6 +5,7 @@
 
 # If this file ever becomes compromised, it's important to regenerate your SECRET_KEY
 # Changing this value will result in all current sessions being invalidated
+system.url-prefix: '<%= @_url_prefix %>'
 system.secret-key: '<%= @secret_key %>'
 system.admin-email: '<%= @admin_email %>'
 redis.clusters:


### PR DESCRIPTION
Sentry depends on this configuration option to correctly render DSNs with its library. The _create project_ script will generate invalid DSNs on a new install without this option.