### PR TITLE
create dsn path even if not bootstrap

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -109,13 +109,13 @@ class sentry::install (
       path    => "${path}/bin:/usr/bin/:/usr/sbin:/bin",
       require => File["${path}/bootstrap.py"],
     }
+  }
 
-    file { "${path}/dsn":
-      ensure  => directory,
-      mode    => '0755',
-      owner   => $user,
-      group   => $group,
-      require => File["${path}/bootstrap.py"],
-    }
+  file { "${path}/dsn":
+    ensure  => directory,
+    mode    => '0755',
+    owner   => $user,
+    group   => $group,
+    require => File["${path}/bootstrap.py"],
   }
 }


### PR DESCRIPTION
This directory needs to exist even on non-bootstrap nodes, as the dsn files get populated on all nodes. It should have not been put inside the bootstrap if block.